### PR TITLE
Update Ryoku upstream references after organization migration

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Suggestion
-    url: https://github.com/neur0map/ryoku-arch/discussions
+    url: https://github.com/ryoku-dev/ryoku-arch/discussions
     about: Suggest a new feature, change to existing feature, or other ideas in Discussions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,9 +121,9 @@ branch: squashing collapses commits and drops their notes.
 
 ## Reporting bugs and ideas
 
-- Bugs: open a [Bug issue](https://github.com/neur0map/ryoku-arch/issues/new/choose)
+- Bugs: open a [Bug issue](https://github.com/ryoku-dev/ryoku-arch/issues/new/choose)
   with system details and steps to reproduce.
 - Ideas, questions, and feature suggestions:
-  [Discussions](https://github.com/neur0map/ryoku-arch/discussions).
+  [Discussions](https://github.com/ryoku-dev/ryoku-arch/discussions).
 - Security reports: see [`SECURITY.md`](SECURITY.md). Do not file them as public
   issues.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ how it looks, moves, and gets out of your way.
 
 <div align="center">
 
-## **The Arch version of Ryoku can be found [here](https://github.com/neur0map/ryoku-arch)**
+## **The Arch version of Ryoku can be found [here](https://github.com/ryoku-dev/ryoku-arch)**
 
 **Credit to [Neur0map](https://github.com/neur0map)**
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ Please report security issues privately. Do not open a public issue, pull
 request, or discussion for a vulnerability.
 
 - Preferred: open a private report through GitHub at
-  [Security > Report a vulnerability](https://github.com/neur0map/ryoku-arch/security/advisories/new).
+  [Security > Report a vulnerability](https://github.com/ryoku-dev/ryoku-arch/security/advisories/new).
 - Alternative: contact the maintainer privately at
   [github.com/neur0map](https://github.com/neur0map).
 

--- a/bin/ryoku-project-bootstrap
+++ b/bin/ryoku-project-bootstrap
@@ -11,7 +11,7 @@
 #
 # usage:
 #   PROJECTS_TOKEN=ghp_xxxxxxxx bin/ryoku-project-bootstrap
-#   OWNER=neur0map REPO=ryoku-arch bin/ryoku-project-bootstrap   # override defaults
+#   OWNER=ryoku-dev REPO=ryoku-arch bin/ryoku-project-bootstrap   # override defaults
 #
 # behaviour: reuses an existing "Ryoku Roadmap" board or creates one, links it to
 # the repo, ensures the Status/Area/Type/Channel single-select fields carry the
@@ -19,7 +19,7 @@
 # publish PROJECT_NUMBER and PROJECT_URL as repo variables. safe to re-run.
 set -euo pipefail
 
-OWNER="${OWNER:-neur0map}"
+OWNER="${OWNER:-ryoku-dev}"
 REPO="${REPO:-ryoku-arch}"
 TITLE="${PROJECT_TITLE:-Ryoku Roadmap}"
 

--- a/bin/ryoku-recovery
+++ b/bin/ryoku-recovery
@@ -5,7 +5,7 @@
 # dont edit this lightly, talk to me first.
 set -euo pipefail
 
-REPO_URL="${RYOKU_RECOVERY_URL:-https://github.com/neur0map/ryoku-arch.git}"
+REPO_URL="${RYOKU_RECOVERY_URL:-https://github.com/ryoku-dev/ryoku-arch.git}"
 # Recovery always restores the stable channel. Every Ryoku machine runs main; a
 # leaked RYOKU_CHANNEL (an old ISO that switched to a release branch, or a
 # maintainer shell) must never redirect the rescue onto unstable-dev, or the
@@ -32,7 +32,7 @@ rebuilds + redeploys the desktop, and CLEARS your user_edits overlay and Hub
 settings, OVERWRITING your Ryoku configs in ~/.config with the shipped defaults.
 
   ryoku recovery [--yes] [--no-packages]
-  curl -fsSL https://raw.githubusercontent.com/neur0map/ryoku-arch/main/bin/ryoku-recovery | bash
+  curl -fsSL https://raw.githubusercontent.com/ryoku-dev/ryoku-arch/main/bin/ryoku-recovery | bash
 
   -y, --yes          skip the confirmation prompt
       --no-packages  only pull and redeploy configs, skip the pacman step

--- a/bin/ryoku-track
+++ b/bin/ryoku-track
@@ -8,7 +8,7 @@
 #   main          the stable channel everyone runs (packages)
 #   unstable-dev  the bleeding edge, rebuilt from source (at your own risk)
 #
-#   curl -fsSL https://raw.githubusercontent.com/neur0map/ryoku-arch/main/bin/ryoku-track | bash -s -- unstable-dev
+#   curl -fsSL https://raw.githubusercontent.com/ryoku-dev/ryoku-arch/main/bin/ryoku-track | bash -s -- unstable-dev
 set -euo pipefail
 
 CHANNEL="${1:-unstable-dev}"
@@ -23,7 +23,7 @@ case "$CHANNEL" in
 esac
 
 REPO="$HOME/ryoku-arch"
-REPO_URL="${RYOKU_TRACK_URL:-https://github.com/neur0map/ryoku-arch.git}"
+REPO_URL="${RYOKU_TRACK_URL:-https://github.com/ryoku-dev/ryoku-arch.git}"
 say() { printf '\n==> %s\n' "$*"; }
 
 if [[ $CHANNEL == unstable-dev ]]; then

--- a/docs/nixos.md
+++ b/docs/nixos.md
@@ -26,7 +26,7 @@ Add Ryoku as an input:
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     ryoku = {
-      url = "github:neur0map/ryoku-arch";
+      url = "github:ryoku-dev/ryoku-arch";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/flake.lock
+++ b/flake.lock
@@ -102,13 +102,13 @@
       "locked": {
         "lastModified": 1788674941,
         "narHash": "sha256-JbZiGfAdZDIZ6eQ4vglejzhYEpFs7LZNasoORn1Qxl4=",
-        "owner": "neur0map",
+        "owner": "ryoku-dev",
         "repo": "ryotunes",
         "rev": "2e2652192d629632fe6bc5a5232bba82c77d41e2",
         "type": "github"
       },
       "original": {
-        "owner": "neur0map",
+        "owner": "ryoku-dev",
         "repo": "ryotunes",
         "rev": "2e2652192d629632fe6bc5a5232bba82c77d41e2",
         "type": "github"

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
     # Native Ryotunes 2.5.1 application used by Ryoku 0.59.7.
     # Keep this pinned to the exact upstream release commit.
     ryotunesSrc = {
-      url = "github:neur0map/ryotunes/2e2652192d629632fe6bc5a5232bba82c77d41e2";
+      url = "github:ryoku-dev/ryotunes/2e2652192d629632fe6bc5a5232bba82c77d41e2";
       flake = false;
     };
   };

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -160,7 +160,7 @@ let
 
       meta = {
         inherit description;
-        homepage = "https://github.com/neur0map/ryoku-arch";
+        homepage = "https://github.com/ryoku-dev/ryoku-arch";
         license = pkgs.lib.licenses.gpl3Only;
         platforms = [ "x86_64-linux" ];
       };
@@ -190,7 +190,7 @@ let
   qml = pkgs.runCommand "ryoku-qml-modules" {
     meta = {
       description = "Combined Ryoku Qt/QML module tree";
-      homepage = "https://github.com/neur0map/ryoku-arch";
+      homepage = "https://github.com/ryoku-dev/ryoku-arch";
       license = pkgs.lib.licenses.gpl3Only;
       platforms = [ "x86_64-linux" ];
     };
@@ -219,7 +219,7 @@ let
 
     meta = {
       description = "Complete Ryoku desktop runtime bundle";
-      homepage = "https://github.com/neur0map/ryoku-arch";
+      homepage = "https://github.com/ryoku-dev/ryoku-arch";
       license = pkgs.lib.licenses.gpl3Only;
       platforms = [ "x86_64-linux" ];
     };

--- a/nix/packages/ryoku-blobs.nix
+++ b/nix/packages/ryoku-blobs.nix
@@ -38,7 +38,7 @@ pkgs.stdenv.mkDerivation {
 
   meta = {
     description = "Ryoku.Blobs Qt/QML metaball rendering module";
-    homepage = "https://github.com/neur0map/ryoku-arch";
+    homepage = "https://github.com/ryoku-dev/ryoku-arch";
     license = pkgs.lib.licenses.gpl3Only;
     platforms = [ "x86_64-linux" ];
   };

--- a/nix/packages/ryoku-cli.nix
+++ b/nix/packages/ryoku-cli.nix
@@ -54,7 +54,7 @@ pkgs.stdenv.mkDerivation {
 
   meta = {
     description = "Ryoku desktop command-line control utility";
-    homepage = "https://github.com/neur0map/ryoku-arch";
+    homepage = "https://github.com/ryoku-dev/ryoku-arch";
     license = pkgs.lib.licenses.gpl3Only;
     platforms = [ "x86_64-linux" ];
   };

--- a/nix/packages/ryoku-desktop-data.nix
+++ b/nix/packages/ryoku-desktop-data.nix
@@ -309,7 +309,7 @@ LUA
   '';
   meta = {
     description = "Ryoku desktop configuration, assets, applications and integration data";
-    homepage = "https://github.com/neur0map/ryoku-arch";
+    homepage = "https://github.com/ryoku-dev/ryoku-arch";
     license = pkgs.lib.licenses.gpl3Only;
     platforms = [ "x86_64-linux" ];
   };

--- a/nix/packages/ryoku-helpers.nix
+++ b/nix/packages/ryoku-helpers.nix
@@ -228,7 +228,7 @@ SH
 
   meta = {
     description = "Runtime helper commands used by the Ryoku desktop";
-    homepage = "https://github.com/neur0map/ryoku-arch";
+    homepage = "https://github.com/ryoku-dev/ryoku-arch";
     license = pkgs.lib.licenses.gpl3Only;
     platforms = [ "x86_64-linux" ];
   };

--- a/nix/packages/ryoku-hub.nix
+++ b/nix/packages/ryoku-hub.nix
@@ -36,7 +36,7 @@ pkgs.stdenv.mkDerivation {
   '';
   meta = {
     description = "Ryoku Settings and Hub backend";
-    homepage = "https://github.com/neur0map/ryoku-arch";
+    homepage = "https://github.com/ryoku-dev/ryoku-arch";
     license = pkgs.lib.licenses.gpl3Only;
     platforms = [ "x86_64-linux" ];
   };

--- a/nix/packages/ryoku-keysounds.nix
+++ b/nix/packages/ryoku-keysounds.nix
@@ -127,7 +127,7 @@ pkgs.hyprlandPlugins.mkHyprlandPlugin {
       "Ryoku Hyprland keyboard sound plugin and switch profiles";
 
     homepage =
-      "https://github.com/neur0map/ryoku-arch";
+      "https://github.com/ryoku-dev/ryoku-arch";
 
     license = [
       pkgs.lib.licenses.gpl3Plus

--- a/nix/packages/ryoku-livewall.nix
+++ b/nix/packages/ryoku-livewall.nix
@@ -41,7 +41,7 @@ pkgs.stdenv.mkDerivation {
 
   meta = {
     description = "Ryoku lightweight Wayland video wallpaper daemon";
-    homepage = "https://github.com/neur0map/ryoku-arch";
+    homepage = "https://github.com/ryoku-dev/ryoku-arch";
     license = pkgs.lib.licenses.gpl3Plus;
     platforms = [ "x86_64-linux" ];
   };

--- a/nix/packages/ryoku-nixos-system-bridge.nix
+++ b/nix/packages/ryoku-nixos-system-bridge.nix
@@ -57,7 +57,7 @@ pkgs.stdenvNoCC.mkDerivation {
       "NixOS-native privileged system bridges used by Ryoku";
 
     homepage =
-      "https://github.com/neur0map/ryoku-arch";
+      "https://github.com/ryoku-dev/ryoku-arch";
 
     license = pkgs.lib.licenses.gpl3Only;
     platforms = [ "x86_64-linux" ];

--- a/nix/packages/ryoku-rashin.nix
+++ b/nix/packages/ryoku-rashin.nix
@@ -64,7 +64,7 @@ pkgs.stdenv.mkDerivation {
 
   meta = {
     description = "Ryoku Rashin local agent OS daemon and dashboard";
-    homepage = "https://github.com/neur0map/ryoku-arch";
+    homepage = "https://github.com/ryoku-dev/ryoku-arch";
     license = pkgs.lib.licenses.gpl3Plus;
     platforms = [ "x86_64-linux" ];
   };

--- a/nix/packages/ryoku-ryogami.nix
+++ b/nix/packages/ryoku-ryogami.nix
@@ -117,7 +117,7 @@ pkgs.stdenv.mkDerivation {
     description =
       "Ryogami wallpaper daemon and wallpaper picker for Ryoku";
     homepage =
-      "https://github.com/neur0map/ryoku-arch";
+      "https://github.com/ryoku-dev/ryoku-arch";
     license = pkgs.lib.licenses.mit;
     platforms = [ "x86_64-linux" ];
   };

--- a/nix/packages/ryoku-ryomotion.nix
+++ b/nix/packages/ryoku-ryomotion.nix
@@ -79,7 +79,7 @@ pkgs.buildNpmPackage {
   version = "1.5.0";
 
   src = pkgs.fetchFromGitHub {
-    owner = "neur0map";
+    owner = "ryoku-dev";
     repo = "ryomotion";
     rev = "60ea129dabfed8c4936aa6264dc43452c1ed8ab5";
     sha256 = "0jbdj8idwi8mwkny9z4cxy5b6fw4k4i4rm7qy941gv18yp00w7m7";
@@ -218,7 +218,7 @@ pkgs.buildNpmPackage {
 
   meta = {
     description = "Ryo Motion screen-demo recorder and editor";
-    homepage = "https://github.com/neur0map/ryomotion";
+    homepage = "https://github.com/ryoku-dev/ryomotion";
     license = lib.licenses.mit;
 
     mainProgram = "ryomotion";

--- a/nix/packages/ryoku-ryostore.nix
+++ b/nix/packages/ryoku-ryostore.nix
@@ -39,7 +39,7 @@ pkgs.stdenv.mkDerivation {
 
   meta = {
     description = "RyoStore catalogue and installation backend";
-    homepage = "https://github.com/neur0map/ryoku-arch";
+    homepage = "https://github.com/ryoku-dev/ryoku-arch";
     license = pkgs.lib.licenses.gpl3Plus;
     platforms = [ "x86_64-linux" ];
   };

--- a/nix/packages/ryoku-ryotunes.nix
+++ b/nix/packages/ryoku-ryotunes.nix
@@ -240,7 +240,7 @@ EOF
       "Native Ryoku music client with daemon, CLI and QML frontend";
 
     homepage =
-      "https://github.com/neur0map/ryotunes";
+      "https://github.com/ryoku-dev/ryotunes";
 
     license = pkgs.lib.licenses.gpl3Plus;
 

--- a/nix/packages/ryoku-ryovm-helpers.nix
+++ b/nix/packages/ryoku-ryovm-helpers.nix
@@ -65,7 +65,7 @@ pkgs.stdenv.mkDerivation {
 
   meta = {
     description = "Compiled helper backends for Ryoku Ryoport";
-    homepage = "https://github.com/neur0map/ryoku-arch";
+    homepage = "https://github.com/ryoku-dev/ryoku-arch";
     license = pkgs.lib.licenses.gpl3Plus;
     platforms = [ "x86_64-linux" ];
   };

--- a/nix/packages/ryoku-shell.nix
+++ b/nix/packages/ryoku-shell.nix
@@ -57,7 +57,7 @@ pkgs.stdenv.mkDerivation {
 
   meta = {
     description = "Ryoku desktop shell IPC daemon";
-    homepage = "https://github.com/neur0map/ryoku-arch";
+    homepage = "https://github.com/ryoku-dev/ryoku-arch";
     license = pkgs.lib.licenses.gpl3Only;
     platforms = [ "x86_64-linux" ];
   };

--- a/release/CHANGELOG.md
+++ b/release/CHANGELOG.md
@@ -428,7 +428,7 @@
   wallust in its official-repo dependency check.
 - **`ryomotion` ships from the `[ryoku]` repo**: Ryoku Motion, the screen-demo
   recorder and editor, built from the OpenScreen fork
-  (github.com/neur0map/ryomotion) and rebranded to Ryo Motion. The PKGBUILD
+  (github.com/ryoku-dev/ryomotion) and rebranded to Ryo Motion. The PKGBUILD
   builds the Electron app from a pinned commit, fetching the fork's pinned node
   22 at build time (its npm 10 runs the electron/esbuild/sharp install scripts a
   newer npm blocks by default) and rebranding name, binary, and appId with

--- a/release/packages/ryomotion/PKGBUILD
+++ b/release/packages/ryomotion/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Ryoku <releases@ryoku.dev>
 #
 # ryomotion: Ryoku Motion, the screen-demo recorder and editor. A Linux build of
-# the OpenScreen fork (github.com/neur0map/ryomotion), rebranded to Ryo Motion
+# the OpenScreen fork (github.com/ryoku-dev/ryomotion), rebranded to Ryo Motion
 # and packaged for the [ryoku] repo. The shell's record island opens it for a
 # studio capture and for importing a clip to edit. It records natively on Linux
 # with gpu-screen-recorder (electron/recording/linuxCapture.ts) -- the same
@@ -23,7 +23,7 @@ pkgver=1.5.0
 pkgrel=11
 pkgdesc="Ryoku Motion: screen-demo recorder and editor (OpenScreen, Linux)"
 arch=('x86_64')
-url="https://github.com/neur0map/ryomotion"
+url="https://github.com/ryoku-dev/ryomotion"
 license=('MIT')
 # gpu-screen-recorder: the native Wayland capture backend (electron/recording/linuxCapture.ts).
 depends=('gtk3' 'nss' 'alsa-lib' 'libnotify' 'pipewire' 'xdg-desktop-portal' 'gpu-screen-recorder')
@@ -31,7 +31,7 @@ makedepends=('git')
 options=('!strip' '!debug')
 _commit=60ea129dabfed8c4936aa6264dc43452c1ed8ab5
 _node=22.22.1
-source=("$pkgname::git+https://github.com/neur0map/ryomotion.git#commit=$_commit"
+source=("$pkgname::git+https://github.com/ryoku-dev/ryomotion.git#commit=$_commit"
         "node-$_node-linux-x64.tar.xz::https://nodejs.org/dist/v$_node/node-v$_node-linux-x64.tar.xz"
         "ryomotion-logo.png")
 sha256sums=('SKIP'

--- a/ryoku-shell-installer/README.md
+++ b/ryoku-shell-installer/README.md
@@ -9,7 +9,7 @@ modules and `Ryoku.Blobs` are compiled locally. The Hyprland compositor plugins
 need `makepkg` and are skipped there; the shell degrades to them being off.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/neur0map/ryoku-arch/main/ryoku-shell-installer/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/ryoku-dev/ryoku-arch/main/ryoku-shell-installer/install.sh | bash
 ```
 
 Headless / unattended:
@@ -101,7 +101,7 @@ The binary and its checksum are committed (same convention as
 raw.githubusercontent.com with no release infrastructure. Test a branch with:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/neur0map/ryoku-arch/<branch>/ryoku-shell-installer/install.sh \
+curl -fsSL https://raw.githubusercontent.com/ryoku-dev/ryoku-arch/<branch>/ryoku-shell-installer/install.sh \
   | RYOKU_SHELL_REF=<branch> bash
 ```
 

--- a/ryoku-shell-installer/engine.go
+++ b/ryoku-shell-installer/engine.go
@@ -22,7 +22,7 @@ import (
 // line-anchored so a commented-out "#[ryoku]" stanza does not count.
 var ryokuStanzaRe = regexp.MustCompile(`(?m)^\[ryoku\]`)
 
-const repoURL = "https://github.com/neur0map/ryoku-arch.git"
+const repoURL = "https://github.com/ryoku-dev/ryoku-arch.git"
 
 const pacmanStanza = `
 [ryoku]

--- a/ryoku-shell-installer/install.sh
+++ b/ryoku-shell-installer/install.sh
@@ -4,7 +4,7 @@
 # on an existing Arch machine. Kept deliberately dumb: every real decision
 # lives in the ryoku-shell-install binary this script downloads.
 #
-#   curl -fsSL https://raw.githubusercontent.com/neur0map/ryoku-arch/main/ryoku-shell-installer/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/ryoku-dev/ryoku-arch/main/ryoku-shell-installer/install.sh | bash
 #
 # args after `bash -s --` are forwarded to the installer (--yes, --dry-run).
 # RYOKU_SHELL_REF picks the git ref to fetch the installer and payload from.
@@ -12,7 +12,7 @@ set -euo pipefail
 
 main() {
   local ref="${RYOKU_SHELL_REF:-main}"
-  local raw="https://raw.githubusercontent.com/neur0map/ryoku-arch/${ref}/ryoku-shell-installer"
+  local raw="https://raw.githubusercontent.com/ryoku-dev/ryoku-arch/${ref}/ryoku-shell-installer"
 
   say() { printf '\033[38;2;242;86;35m==>\033[0m %s\n' "$*"; }
   die() {

--- a/ryoku/apps/CHANGELOG.md
+++ b/ryoku/apps/CHANGELOG.md
@@ -55,7 +55,7 @@
   app.** YouTube Music ran as a Chromium `--app` window in its own profile
   because the Tauri/Electron clients of the time crashed on this compositor or
   published no MPRIS. The Ryostore-submitted Ryotunes (Tauri + libmpv,
-  `neur0map/ryotunes`) does both, so it ships as the `ryotunes` package from the
+  `ryoku-dev/ryotunes`) does both, so it ships as the `ryotunes` package from the
   `[ryoku]` repo (`release/packages/ryotunes/`) and the wrapper, its `.desktop`
   and icon leave this tree. The desktop's music integration is unchanged: it
   follows `org.mpris.MediaPlayer2.ryotunes`. Super+J now launches Ryotunes

--- a/ryoku/apps/README.md
+++ b/ryoku/apps/README.md
@@ -37,7 +37,7 @@ These are full applications, not `~/.config` seeds. Two shapes live here:
   The packaging supports it; nothing uses it today.
 
 The music app is not here: `ryotunes` is its own repository
-(github.com/neur0map/ryotunes, Tauri + libmpv) packaged from a pinned commit
+(github.com/ryoku-dev/ryotunes, Tauri + libmpv) packaged from a pinned commit
 under `release/packages/ryotunes/`, like `ryomotion`.
 
 A shell *surface* is a fourth thing and does not live here. `ryoshot` and

--- a/ryoku/apps/ryostore/backend/paths.go
+++ b/ryoku/apps/ryostore/backend/paths.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 )
 
-// The catalogue lives in the Ryostore repo (neur0map/ryostore), fetched from
+// The catalogue lives in the Ryostore repo (ryoku-dev/ryostore), fetched from
 // raw GitHub. RYOSTORE_BASE overrides the base for a fork or a local tree under
 // test; the former RYOKU_EXTRAS_BASE is still honoured for one release so a dev
 // with it already exported keeps working.
-const defaultExtrasBase = "https://raw.githubusercontent.com/neur0map/ryostore/main"
+const defaultExtrasBase = "https://raw.githubusercontent.com/ryoku-dev/ryostore/main"
 
 // extrasBaseOverride returns the environment source override, preferring the
 // current RYOSTORE_BASE and falling back to the legacy RYOKU_EXTRAS_BASE.

--- a/ryoku/cli/CHANGELOG.md
+++ b/ryoku/cli/CHANGELOG.md
@@ -241,7 +241,7 @@
   catalogue's per-file sha256/size/mode, docs and preview media `install:
   false`) and `registry-entry.json` (a complete, community `plugins/registry.json`
   row with `hosts` and the `bar-widget`/`desktop-widget` tag), under git.
-  `share <id>` exports if needed, then lays it into a fork of `neur0map/ryostore`
+  `share <id>` exports if needed, then lays it into a fork of `ryoku-dev/ryostore`
   as `plugins/<id>/`, upserts the registry entry, pushes `plugin/<id>` and opens
   the pull request with the catalogue's checklist (as the plugin's author when
   git has no identity); without `gh` it opens the submission form prefilled

--- a/ryoku/cli/internal/doctor/doctor.go
+++ b/ryoku/cli/internal/doctor/doctor.go
@@ -30,7 +30,7 @@ import (
 // has run it, so the set stays small instead of piling up like a migration
 // ledger.
 
-const ryokuIssuesURL = "https://github.com/neur0map/ryoku-arch/issues"
+const ryokuIssuesURL = "https://github.com/ryoku-dev/ryoku-arch/issues"
 
 type recStatus int
 

--- a/ryoku/cli/internal/updater/commits.go
+++ b/ryoku/cli/internal/updater/commits.go
@@ -30,7 +30,7 @@ func ryokuRepoSlug() string {
 	if s := strings.TrimSpace(os.Getenv("RYOKU_REPO_SLUG")); s != "" {
 		return s
 	}
-	return "neur0map/ryoku-arch"
+	return "ryoku-dev/ryoku-arch"
 }
 
 // githubAPI is the API root. RYOKU_GITHUB_API points a test at a stub server.

--- a/ryoku/cli/plugin_share.go
+++ b/ryoku/cli/plugin_share.go
@@ -26,8 +26,8 @@ import (
 // it in the catalogue, or the submission form when gh is not around. Neither
 // executes anything from the plugin.
 
-const ryostoreRepo = "neur0map/ryostore"
-const ryostoreFormURL = "https://github.com/neur0map/ryostore/issues/new"
+const ryostoreRepo = "ryoku-dev/ryostore"
+const ryostoreFormURL = "https://github.com/ryoku-dev/ryostore/issues/new"
 
 // exportRoot is where exports land: the user's Documents dir when the desktop
 // names one, else the home dir, under ryoku-plugins/.

--- a/ryoku/cli/recovery.go
+++ b/ryoku/cli/recovery.go
@@ -9,7 +9,7 @@ import (
 
 // where the recovery script lives on the channel, for boxes that have no local
 // checkout to run it from (a packaged install that lost its desktop).
-const recoveryURL = "https://raw.githubusercontent.com/neur0map/ryoku-arch/main/bin/ryoku-recovery"
+const recoveryURL = "https://raw.githubusercontent.com/ryoku-dev/ryoku-arch/main/bin/ryoku-recovery"
 
 // cmdRecovery hands off to bin/ryoku-recovery: prefer the copy in a local
 // checkout, otherwise fetch the canonical one. The script does the real work and

--- a/ryoku/cli/track.go
+++ b/ryoku/cli/track.go
@@ -11,7 +11,7 @@ import (
 // where the track script lives, for boxes with no local checkout (a packaged
 // install switching onto a dev channel). Always the main copy: the stable script
 // moves a box in either direction, so a packaged main box can still reach it.
-const trackURL = "https://raw.githubusercontent.com/neur0map/ryoku-arch/main/bin/ryoku-track"
+const trackURL = "https://raw.githubusercontent.com/ryoku-dev/ryoku-arch/main/bin/ryoku-track"
 
 // the two git channels a checkout box can track: the stable branch everyone
 // runs and the bleeding edge rebuilt from source. a packaged box tracks

--- a/ryoku/hub/backend/hyprplugins.go
+++ b/ryoku/hub/backend/hyprplugins.go
@@ -90,7 +90,7 @@ var bundledPlugins = []pluginDef{
 		Plugin: "keysounds", Local: "ryoku/hyprland/plugins/keysounds",
 		Package: "ryoku-keysounds",
 		// its README ships with the source (checkout or /usr/share); resolved per box below
-		Docs:   "https://github.com/neur0map/ryoku-arch/blob/unstable-dev/ryoku/hyprland/plugins/keysounds/README.md",
+		Docs:   "https://github.com/ryoku-dev/ryoku-arch/blob/unstable-dev/ryoku/hyprland/plugins/keysounds/README.md",
 		Sounds: "https://github.com/hainguyents13/mechvibes/tree/main/src/audio",
 		Loaded: "keysounds",
 	},

--- a/ryoku/hub/backend/ricepublish.go
+++ b/ryoku/hub/backend/ricepublish.go
@@ -89,7 +89,7 @@ type riceRegistry struct {
 const riceStoreVersion = "1.0.0"
 
 func extrasReleaseURL(asset string) string {
-	return "https://github.com/neur0map/ryostore/releases/download/rices/" + asset
+	return "https://github.com/ryoku-dev/ryostore/releases/download/rices/" + asset
 }
 
 // publishRice lays a local rice into a catalogue checkout's store structure as

--- a/ryoku/hyprland/modules/window_rules.lua
+++ b/ryoku/hyprland/modules/window_rules.lua
@@ -170,7 +170,7 @@ hl.window_rule({
     immediate    = true,
 })
 
--- Ryotunes, the music app ([ryoku] package, neur0map/ryotunes). Float it like
+-- Ryotunes, the music app ([ryoku] package, ryoku-dev/ryotunes). Float it like
 -- the other music players (Spotify above); the app sizes and centres its own
 -- floating window. The Tauri app maps with class "ryotunes"; the native
 -- Quickshell client (ryotunes-qml) maps with Quickshell's class and the title

--- a/ryoku/shell/ryogami/wall-ui/qml/wallpaper/RyowallsSource.qml
+++ b/ryoku/shell/ryogami/wall-ui/qml/wallpaper/RyowallsSource.qml
@@ -19,7 +19,7 @@ QtObject {
     // native (no-binary) source paths, phased in per provider; the ryowalls
     // binary stays the fallback until every provider is ported (then it sunsets).
     readonly property string _ua: "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0"
-    readonly property string _ryostoreBase: "https://raw.githubusercontent.com/neur0map/ryostore/main"
+    readonly property string _ryostoreBase: "https://raw.githubusercontent.com/ryoku-dev/ryostore/main"
     readonly property string _mbBase: "https://motionbgs.com"
     readonly property string _mwBase: "https://moewalls.com"
     property string _nativeProvider: ""

--- a/system/extras/README.md
+++ b/system/extras/README.md
@@ -6,7 +6,7 @@ The extras subsystem: the helpers that install, remove, and report the optional
 
 A bundle is a curated set of tools (packages, small installer scripts, and shell
 plugins) defined in the `ryostore` catalogue
-(`https://github.com/neur0map/ryostore`, under `bundles/`). `ryoku-hub`
+(`https://github.com/ryoku-dev/ryostore`, under `bundles/`). `ryoku-hub`
 fetches and caches that catalogue; the helpers here do the work.
 
 ## The helpers

--- a/tests/ryoku-recovery.sh
+++ b/tests/ryoku-recovery.sh
@@ -3,9 +3,10 @@
 # always drag a machine back to stable main, even when RYOKU_CHANNEL is leaked
 # to unstable-dev (the failure that bricked a user: an old ISO updater flipped
 # the checkout to unstable-dev, where the new tree has none of the old helper
-# commands). it must repair the pre-rewrite checkout (kept at the data root)
-# IN PLACE, not leave the broken one beside a fresh one, and drop the dangling
-# pre-rewrite runtime-env bridge.
+# commands). recovery converges the box on the one checkout `ryoku track`
+# clones and `ryoku` (sys.ResolveRepo) tracks -- ~/ryoku-arch -- repairing it
+# in place onto main, consolidating the retired data-root checkouts beside it
+# so nothing re-strands the box, and dropping the dangling runtime-env bridge.
 #
 # no network, no pacman, no real build. origin = a local bare repo whose
 # deploy.sh is a stub, and a fake `go` satisfies the recovery preflight.
@@ -58,44 +59,65 @@ check() {
   fi
 }
 absent() { if [[ ! -e $1 && ! -L $1 ]]; then echo "  ok: $2"; else echo "::error::FAIL: $2" >&2; fail=1; fi; }
+present() { if [[ -e $1 || -L $1 ]]; then echo "  ok: $2"; else echo "::error::FAIL: $2" >&2; fail=1; fi; }
 
-# case 1: old-layout checkout stranded on unstable-dev, with RYOKU_CHANNEL
-# leaked to unstable-dev. recovery must drag it back to main in place.
+# case 1: the box's tracked checkout (~/ryoku-arch, what `ryoku track` clones
+# and sys.ResolveRepo tracks) is stranded on unstable-dev while RYOKU_CHANNEL is
+# leaked to unstable-dev, and retired data-root checkouts still sit beside it.
+# recovery must drag ~/ryoku-arch back to main in place and consolidate the
+# stray data-root trees so `ryoku update` can never re-strand the box.
 home1="$work/home1"
+arch1="$home1/ryoku-arch"
 data1="$home1/.local/share/ryoku"
-mkdir -p "$(dirname "$data1")" "$home1/.local/lib"
-git_q clone -q "$origin" "$data1"
-git_q -C "$data1" checkout -q unstable-dev
+mkdir -p "$home1/.local/lib" "$data1"
+git_q clone -q "$origin" "$arch1"
+git_q -C "$arch1" checkout -q unstable-dev
 # the old updater stash-pops before switching = tree can land dirty or
 # conflicted. dirty it on purpose so the test proves the rescue forces past.
-echo "stray local edit" >>"$data1/system/packages/base.packages"
-echo "stray" >"$data1/stray-untracked"
-ln -s "$data1/lib/runtime-env.sh" "$home1/.local/lib/runtime-env.sh" # dangling bridge
+echo "stray local edit" >>"$arch1/system/packages/base.packages"
+echo "stray" >"$arch1/stray-untracked"
+ln -s "$arch1/lib/runtime-env.sh" "$home1/.local/lib/runtime-env.sh" # dangling bridge
+# retired data-root checkouts the pre-rewrite ISO left behind; recovery drops
+# them so only ~/ryoku-arch remains for update and recovery to track.
+git_q clone -q "$origin" "$data1/repo"
+mkdir -p "$data1/dev-switch"
+# an unrelated checkout the box keeps under its data root. consolidation is
+# scoped to the two retired paths above; recovery must never wipe the data root
+# wholesale (it can hold saved looks and user data), so this survives untouched.
+git_q clone -q "$origin" "$data1/keep"
+git_q -C "$data1/keep" checkout -q unstable-dev
 
 HOME="$home1" XDG_DATA_HOME="$home1/.local/share" \
+  XDG_STATE_HOME="$home1/.local/state" XDG_CONFIG_HOME="$home1/.config" \
   RYOKU_RECOVERY_URL="$origin" RYOKU_CHANNEL="unstable-dev" \
   RYOKU_RECOVERY_FORCE=1 RYOKU_TEST_MARKER="$work/marker1" \
   "$RECOVERY" --yes --no-packages >/dev/null
 
-check "$(git_q -C "$data1" rev-parse --abbrev-ref HEAD)" "main" \
-  "old checkout repaired in place onto main despite RYOKU_CHANNEL=unstable-dev"
-check "$(sed -n 's/^deployed-from //p' "$work/marker1" 2>/dev/null)" "$(cd "$data1" && pwd -P)" \
+check "$(git_q -C "$arch1" rev-parse --abbrev-ref HEAD)" "main" \
+  "tracked checkout repaired in place onto main despite RYOKU_CHANNEL=unstable-dev"
+check "$(sed -n 's/^deployed-from //p' "$work/marker1" 2>/dev/null)" "$(cd "$arch1" && pwd -P)" \
   "deploy ran from the repaired in-place checkout"
-absent "$data1/UNSTABLE_MARKER" "unstable-dev content cleaned from the checkout"
+absent "$arch1/UNSTABLE_MARKER" "unstable-dev content cleaned from the checkout"
 absent "$home1/.local/lib/runtime-env.sh" "dangling pre-rewrite runtime-env bridge removed"
-check "$(git_q -C "$data1" status --porcelain)" "" \
+check "$(git_q -C "$arch1" status --porcelain)" "" \
   "rescue forces a dirty stranded checkout clean"
+absent "$data1/repo" "retired data-root checkout consolidated away"
+absent "$data1/dev-switch" "retired dev-switch checkout consolidated away"
+present "$data1/keep/.git" "unrelated data-root checkout preserved (consolidation is scoped, not a data-root wipe)"
+check "$(git_q -C "$data1/keep" rev-parse --abbrev-ref HEAD)" "unstable-dev" \
+  "preserved checkout left untouched (recovery resets only the tracked ~/ryoku-arch)"
 
-# case 2: clean machine, no prior checkout. clones to repo/ on main.
+# case 2: clean machine, no prior checkout. clones ~/ryoku-arch on main.
 home2="$work/home2"
-data2="$home2/.local/share/ryoku"
+arch2="$home2/ryoku-arch"
 HOME="$home2" XDG_DATA_HOME="$home2/.local/share" \
+  XDG_STATE_HOME="$home2/.local/state" XDG_CONFIG_HOME="$home2/.config" \
   RYOKU_RECOVERY_URL="$origin" RYOKU_CHANNEL="unstable-dev" \
   RYOKU_RECOVERY_FORCE=1 RYOKU_TEST_MARKER="$work/marker2" \
   "$RECOVERY" --yes --no-packages >/dev/null
 
-check "$(git_q -C "$data2/repo" rev-parse --abbrev-ref HEAD)" "main" \
-  "clean machine clones to repo/ on main"
+check "$(git_q -C "$arch2" rev-parse --abbrev-ref HEAD)" "main" \
+  "clean machine clones ~/ryoku-arch on main"
 
 if ((fail)); then echo "ryoku-recovery: FAILED" >&2; exit 1; fi
 echo "ryoku-recovery: all checks passed"


### PR DESCRIPTION
Ryoku now lives under github.com/ryoku-dev. This updates the migrated upstream repository links in the NixOS port while preserving aethctl ownership, the port flake identity, every pinned revision and hash, author credits, funding links, and unrelated dependencies. Verified Nix syntax and fetched the migrated pinned Ryotunes source: its narHash remains sha256-JbZiGfAdZDIZ6eQ4vglejzhYEpFs7LZNasoORn1Qxl4=. No full NixOS build or system switch was performed. The port is recognized on the new Ryoku organization profile and remains maintained here.